### PR TITLE
Adjust gas price and polling interval to match harmony v4.3.2 changes

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ MAX_VALIDATORS_PAGES = 10
 # Path to base web page html contents
 BASE_HTML_PATH = "{}/harmony/robovalidator.html".format(HOME)
 
-BID_GAS_PRICE = 1
+BID_GAS_PRICE = 30
 
 CHANGE_KEY_TIMEOUT_SECONDS = 10
 

--- a/config.py
+++ b/config.py
@@ -21,7 +21,7 @@ PASSPHRASE_PATH = "{}/harmony/passphrase.txt".format(HOME)
 BLS_ALL_KEYS_PATH = "{}/harmony/.hmy/allkeys".format(HOME)
 
 # The slot to target
-TARGET_SLOT = 400
+TARGET_SLOT = 450
 
 # Maximum validator pages to parse
 MAX_VALIDATORS_PAGES = 10

--- a/logic/epoch_logic.py
+++ b/logic/epoch_logic.py
@@ -36,22 +36,22 @@ def get_remaining_seconds_for_current_epoch():
 def get_interval_seconds():
     remaining_seconds = get_remaining_seconds_for_current_epoch()
     if remaining_seconds < TimeUnit.Minute:
-        return 2
-
-    if remaining_seconds < TimeUnit.Minute * 2:
-        return 3
-
-    if remaining_seconds < TimeUnit.Minute * 5:
         return 5
 
-    if remaining_seconds < TimeUnit.Minute * 10:
+    if remaining_seconds < TimeUnit.Minute * 2:
         return 10
 
+    if remaining_seconds < TimeUnit.Minute * 5:
+        return 20
+
+    if remaining_seconds < TimeUnit.Minute * 10:
+        return 45
+
     if remaining_seconds < TimeUnit.Hour:
-        return 30
+        return TimeUnit.Minute
 
     if remaining_seconds < 2 * TimeUnit.Hour:
-        return TimeUnit.Minute
+        return 2 * TimeUnit.Minute
 
     if remaining_seconds < TimeUnit.Day:
         return 5 * TimeUnit.Minute


### PR DESCRIPTION
Per https://discord.com/channels/532383335348043777/616699767594156045/927399392921681951

```
Dear @dev-dao-council, @node-operators, @validator-dao-council we are going to deploy to our S0 leader and explorer 
node an urgent update to increase the minimum gas fee to 30 gwei and rate limit 3 RPCs getStakingNetworkInfo,
GetSuperCommittees, GetCurrentUtilityMetrics. Overall those changes should help mitigating the transaction spam issue
and greatly improving the RPC service stability. 

For Developers, your users may be required to adjust their gas price manually if your application is not using our
recommendation.

For Validators, your auto-bidder scripts may need to be updated and adjusted to reflect the new minimum gas fees and the
RPC rate limits.
```
