### PR TITLE
target.py

### DIFF
--- a/target.py
+++ b/target.py
@@ -1,0 +1,41 @@
+#GET AB CONFIG FILE
+import os
+import sys
+from config import TARGET_SLOT
+
+#UPDATE CONFIG FILE FUNCTION
+def updateAB(fileName, originalText, newText):
+    f = open(fileName,'r')
+    filedata = f.read()
+    f.close()
+
+    newdata = filedata.replace(originalText, newText)
+
+    f = open(fileName,'w')
+    f.write(newdata)
+    f.close()
+    return
+
+def getNewSlot():
+    #OUTPUT AND ASK QUESTION
+    print("Current TARGET_SLOT: ") 
+    print(TARGET_SLOT)
+    print("++++++++")
+    NEWSLOT = input("Enter new SLOT TARGET: ")
+    return NEWSLOT
+ 
+
+if __name__ == '__main__':
+    # Get New Slot
+    NEWSLOT = sys.argv[1] if len(sys.argv) > 1 else getNewSlot()
+
+    # EDIT AUTOBIDDER CONFIG FILE
+    
+    ORIG_TARGET = "TARGET_SLOT = "+str(TARGET_SLOT)
+    NEW_TARGET = "TARGET_SLOT = "+str(NEWSLOT)
+    updateAB("../harmony_autobidder/config.py",ORIG_TARGET,NEW_TARGET)
+    print("++++++++")
+    print("Target slot updated to "+NEWSLOT)
+
+    os.system("tmux kill-ses -t autobidder")
+    os.system("tmux new-session -s autobidder 'python3 ~/harmony_autobidder/autobid.py'")


### PR DESCRIPTION
Added file target.py for launching autobidder with trailing target slot number.

For example, if you'd like to start autobidder with a target of slot 350 you would launch autobidder with:

`python3 target.py 350`

Script will modify target in config.py, checks for a pre-existing tmux session named autobidder, kills it, and starts a fresh one named autobidder.

Use `ctrl+b then d` to detach from the session. `tmux attach` to re-attach to your session. `ctrl+c` to kill your tmux session or you have the option of simply relaunching target.py